### PR TITLE
fix(mapping): typing error

### DIFF
--- a/packages/eva/mapping.json
+++ b/packages/eva/mapping.json
@@ -2244,7 +2244,7 @@
               "h3": {
                 "fontSize": "text-heading-3-font-size",
                 "lineHeight": "text-heading-3-line-height",
-                "fontWeight": "text-heading-4-font-weight"
+                "fontWeight": "text-heading-3-font-weight"
               },
               "h4": {
                 "fontSize": "text-heading-4-font-size",


### PR DESCRIPTION
It seems that there is a typing error in the `h3` definition.