### PR TITLE
fix(processing): filter null values during strict theme processing

### DIFF
--- a/packages/processor/js/src/processor/meta/metaProcessor.ts
+++ b/packages/processor/js/src/processor/meta/metaProcessor.ts
@@ -9,6 +9,7 @@ import { MappingMetaType } from '../mapping/mappingProcessor';
 import { Processor } from '../processor';
 import {
   createAllStyles,
+  isNil,
   toObject,
 } from '../../service';
 
@@ -51,13 +52,10 @@ export class MetaProcessor implements Processor<MappingProcessorParamsType, Them
   }
 
   private getStrictThemeValue(name: string, theme: StrictTheme, fallback?: any) {
+    const key: string = this.isReference(name) ? this.createKeyFromReference(name) : name;
+    const value = this.findValue(key, theme);
 
-    if (this.isReference(name)) {
-      const themeKey: string = this.createKeyFromReference(name);
-      return this.findValue(themeKey, theme) || fallback;
-    }
-
-    return this.findValue(name, theme) || fallback;
+    return isNil(value) ? fallback : value;
   }
 
   private findValue(name: string, theme: StrictTheme): string {

--- a/packages/processor/js/src/service/common/common.service.ts
+++ b/packages/processor/js/src/service/common/common.service.ts
@@ -64,3 +64,14 @@ export function toObject(array: [string, any][]): any {
     return p;
   }, {});
 }
+
+/**
+ * Check value for null or undefined
+ *
+ *
+ * @return boolean
+ * @param value
+ */
+export function isNil(value: any): boolean {
+  return value === undefined || value === null;
+}

--- a/packages/processor/js/src/service/style/style.service.ts
+++ b/packages/processor/js/src/service/style/style.service.ts
@@ -11,6 +11,7 @@ import {
   safe,
   noNulls,
   noDuplicates,
+  isNil,
 } from '../common';
 import {
   getComponentDefaultAppearance,
@@ -292,7 +293,7 @@ function createStateVariations(states: string[], separator: string, result: stri
 function withStrictTokens(mapping: StatelessMappingType, theme: ThemedStyleType): StatelessMappingType {
   return Object.keys(mapping).reduce((acc: StatelessMappingType, next: string): StatelessMappingType => {
     const currentToken: ParameterType = mapping[next];
-    const nextToken: ParameterType = theme[currentToken] || currentToken;
+    const nextToken: ParameterType = isNil(theme[currentToken]) ? currentToken : theme[currentToken];
 
     return { ...acc, [next]: nextToken };
   }, {});


### PR DESCRIPTION
The users complained that they are not able to set `0` values for strict rules. https://github.com/akveo/react-native-ui-kitten/issues/1305

This happens because of wrong processing of `0`.
Mapping rule `border-radius: 4` maps into `borderRadius: 'border-radius'` style instead of `borderRadius: 0` and causes a native crash both for iOS and Android.


