### PR TITLE
feat: reduced styles evaluation for never used variant groups combina…

### DIFF
--- a/packages/eva/mapping.json
+++ b/packages/eva/mapping.json
@@ -213,11 +213,6 @@
             "default": false,
             "priority": 1,
             "scope": "mobile"
-          },
-          "focused": {
-            "default": false,
-            "priority": 2,
-            "scope": "mobile"
           }
         }
       },
@@ -437,8 +432,7 @@
       "appearances": {
         "filled": {
           "mapping": {
-            "textFontFamily": "text-font-family",
-            "iconMarginHorizontal": 4
+            "textFontFamily": "text-font-family"
           },
           "variantGroups": {
             "status": {
@@ -4914,7 +4908,7 @@
           },
           "status": {
             "basic": {
-              "default": false
+              "default": true
             },
             "primary": {
               "default": false
@@ -4941,7 +4935,6 @@
       "appearances": {
         "default": {
           "mapping": {
-            "color": "text-basic-color"
           },
           "variantGroups": {
             "category": {
@@ -5037,13 +5030,21 @@
           }
         },
         "alternative": {
-          "mapping": {
-            "color": "text-alternate-color"
+          "variantGroups": {
+            "status": {
+              "basic": {
+                "color": "text-alternate-color"
+              }
+            }
           }
         },
         "hint": {
-          "mapping": {
-            "color": "text-hint-color"
+          "variantGroups": {
+            "status": {
+              "basic": {
+                "color": "text-hint-color"
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
…tions


This PR contains some performance optimizations. It decreases amount of memory needed to generated styles almost to 25%. It also decreases loading time, but for this one it is a bit harder to provide exact measurements.

The idea here is that previously we generated styles for all possible combinations of variant groups, even those which are never used, because of some default set of variant groups values. For example for `Button` component there were styles that are generated for keys like: 'filled', 'filled.primary', 'filled.tiny' and etc. This keys are kind of invalid as we have default set for `statsus` and `size` variant groups, so even if we omit both properties default key will look like `filled.primary.medium`. 
To simplify: if we have default values for all variant groups for exact component, minimal key which makes sense will be something like `default_appearence.default_var_group1.default_var_group2`, e.i. it should contain 1 appearance value and 1 value for each variant group declared for that component. This PR doesn't include optimizations for states, they are build on top of current approach with no changes for now.

Please notice, there is small change in `Text` component behaviour. Previously there was no default value for `status` variant group, so `hint` and `alternative` had their own colors (`text-hint-color`/`text-alternate-color`) for no `status` and `text-basic-color` for `basic` status. Now `basic` status is default one, so it matches to `text-hint-color`/`text-alternate-color` accordingly. 